### PR TITLE
Allow an attribute named class to set the element class

### DIFF
--- a/src/HtmlToString.elm
+++ b/src/HtmlToString.elm
@@ -72,8 +72,19 @@ nodeRecordToString {tag, children, facts} =
                         |> Just
 
         classes =
-            Dict.get "className" facts.stringOthers
-                |> Maybe.map (\name -> "class=\"" ++ name ++ "\"")
+            Maybe.oneOf
+                [   Dict.get "className" facts.stringOthers
+                        |> Maybe.map (\name -> "class=\"" ++ name ++ "\"")
+                ,   facts.attributes
+                        `Maybe.andThen`
+                            (\attr ->
+                                 Json.Decode.decodeValue
+                                     (Json.Decode.at ["class"] Json.Decode.string)
+                                     attr
+                                |> Result.toMaybe
+                            )
+                        |> Maybe.map (\name -> "class=\"" ++ name ++ "\"")
+                ]
 
         stringOthers =
             Dict.filter (\k v -> k /= "className") facts.stringOthers


### PR DESCRIPTION
elmx uses Http.Attributes.attribute "class" on elements, which leads to this change, adding a fallback to an attribute named "class".  

What do you think?
