### PR TITLE
Keyed node html query fix

### DIFF
--- a/src/Native/ServerSideHelpers.js
+++ b/src/Native/ServerSideHelpers.js
@@ -96,18 +96,9 @@ function triggerEvent(eventName, value, node){
     return A2(_elm_lang$core$Native_Json.run, events[eventName].decoder, value)
 }
 
-function stringify(node) {
-    if (node.type == "keyed-node") {
-        node.children = node.children.map(function(childNode){
-            return childNode["_1"]
-        });
-    }
-    return JSON.stringify(node);
-}
-
 return {
     replaceChildren: replaceChildren,
-    stringify: stringify,
+    stringify: JSON.stringify,
     addAttribute: F2(addAttribute),
     triggerEvent: F3(triggerEvent)
 };

--- a/src/Native/ServerSideHelpers.js
+++ b/src/Native/ServerSideHelpers.js
@@ -96,9 +96,18 @@ function triggerEvent(eventName, value, node){
     return A2(_elm_lang$core$Native_Json.run, events[eventName].decoder, value)
 }
 
+function stringify(node) {
+    if (node.type == "keyed-node") {
+        node.children = node.children.map(function(childNode){
+            return childNode["_1"]
+        });
+    }
+    return JSON.stringify(node);
+}
+
 return {
     replaceChildren: replaceChildren,
-    stringify: JSON.stringify,
+    stringify: stringify,
     addAttribute: F2(addAttribute),
     triggerEvent: F3(triggerEvent)
 };

--- a/src/ServerSide/InternalTypes.elm
+++ b/src/ServerSide/InternalTypes.elm
@@ -73,7 +73,7 @@ decodeNodeType =
                         Json.Decode.map TextTag decodeTextTag
 
                     "keyed-node" ->
-                        decodeKeyedNode
+                        Json.Decode.map NodeEntry decodeKeyedNode
 
                     "node" ->
                         Json.Decode.map NodeEntry decodeNode
@@ -108,23 +108,13 @@ decodeTagger =
         ]
 
 
-decodeKeyedNode : Json.Decode.Decoder NodeType
+decodeKeyedNode : Json.Decode.Decoder NodeRecord
 decodeKeyedNode =
-    Json.Decode.map NodeEntry
-        (Json.Decode.object4 NodeRecord
+    Json.Decode.object4 NodeRecord
         ("tag" := Json.Decode.string)
-        ("children" := Json.Decode.list decodeKeyedNodeType)
+        ("children" := Json.Decode.list (Json.Decode.at [ "_1" ] decodeNodeType))
         ("facts" := decodeFacts)
-        ("descendantsCount" := Json.Decode.int))
-
-
-decodeKeyedNodeType : Json.Decode.Decoder NodeType
-decodeKeyedNodeType =
-    Json.Decode.at [ "_1" ]
-        (Json.Decode.oneOf
-            [ Json.Decode.map TextTag decodeTextTag
-            ]
-        )
+        ("descendantsCount" := Json.Decode.int)
 
 
 decodeNode : Json.Decode.Decoder NodeRecord

--- a/src/ServerSide/InternalTypes.elm
+++ b/src/ServerSide/InternalTypes.elm
@@ -72,6 +72,9 @@ decodeNodeType =
                     "text" ->
                         Json.Decode.map TextTag (decodeTextTag)
 
+                    "keyed-node" ->
+                        Json.Decode.map NodeEntry (decodeNode)
+
                     "node" ->
                         Json.Decode.map NodeEntry (decodeNode)
 

--- a/src/ServerSide/InternalTypes.elm
+++ b/src/ServerSide/InternalTypes.elm
@@ -110,11 +110,16 @@ decodeTagger =
 
 decodeKeyedNode : Json.Decode.Decoder NodeRecord
 decodeKeyedNode =
-    Json.Decode.object4 NodeRecord
-        ("tag" := Json.Decode.string)
-        ("children" := Json.Decode.list (Json.Decode.at [ "_1" ] decodeNodeType))
-        ("facts" := decodeFacts)
-        ("descendantsCount" := Json.Decode.int)
+    let
+        -- elm stores keyed nodes as tuples
+        -- we only want to decode the html, in the second property
+        decodeSecondNode = (Json.Decode.at [ "_1" ] decodeNodeType)
+    in
+        Json.Decode.object4 NodeRecord
+            ("tag" := Json.Decode.string)
+            ("children" := Json.Decode.list decodeSecondNode)
+            ("facts" := decodeFacts)
+            ("descendantsCount" := Json.Decode.int)
 
 
 decodeNode : Json.Decode.Decoder NodeRecord

--- a/src/ServerSide/InternalTypes.elm
+++ b/src/ServerSide/InternalTypes.elm
@@ -70,13 +70,13 @@ decodeNodeType =
             (\typeString ->
                 case typeString of
                     "text" ->
-                        Json.Decode.map TextTag (decodeTextTag)
+                        Json.Decode.map TextTag decodeTextTag
 
                     "keyed-node" ->
-                        Json.Decode.map NodeEntry (decodeNode)
+                        Json.Decode.map NodeEntry decodeNode
 
                     "node" ->
-                        Json.Decode.map NodeEntry (decodeNode)
+                        Json.Decode.map NodeEntry decodeNode
 
                     "custom" ->
                         decodeCustomNode

--- a/src/ServerSide/InternalTypes.elm
+++ b/src/ServerSide/InternalTypes.elm
@@ -73,7 +73,7 @@ decodeNodeType =
                         Json.Decode.map TextTag decodeTextTag
 
                     "keyed-node" ->
-                        Json.Decode.map NodeEntry decodeNode
+                        decodeKeyedNode
 
                     "node" ->
                         Json.Decode.map NodeEntry decodeNode
@@ -106,6 +106,25 @@ decodeTagger =
         , Json.Decode.at [ "text" ] decodeNodeType
         , Json.Decode.at [ "custom" ] decodeNodeType
         ]
+
+
+decodeKeyedNode : Json.Decode.Decoder NodeType
+decodeKeyedNode =
+    Json.Decode.map NodeEntry
+        (Json.Decode.object4 NodeRecord
+        ("tag" := Json.Decode.string)
+        ("children" := Json.Decode.list decodeKeyedNodeType)
+        ("facts" := decodeFacts)
+        ("descendantsCount" := Json.Decode.int))
+
+
+decodeKeyedNodeType : Json.Decode.Decoder NodeType
+decodeKeyedNodeType =
+    Json.Decode.at [ "_1" ]
+        (Json.Decode.oneOf
+            [ Json.Decode.map TextTag decodeTextTag
+            ]
+        )
 
 
 decodeNode : Json.Decode.Decoder NodeRecord

--- a/tests/BasicTests.elm
+++ b/tests/BasicTests.elm
@@ -1,7 +1,5 @@
 module BasicTests exposing (..)
 
--- where
-
 import HtmlToString exposing (..)
 import ServerSide.InternalTypes exposing (..)
 import ServerSide.Helpers exposing (..)
@@ -282,6 +280,50 @@ twoChildFormDecoded =
             }
 
 
+keyedNodeWithText : Html.Html msg
+keyedNodeWithText =
+    Keyed.ul [] [ ("0", Html.text "Hello!") ]
+
+
+keyedNodeWithTextDecoded : NodeType
+keyedNodeWithTextDecoded =
+    NodeEntry
+        { tag = "ul"
+        , children = [ TextTag { text = "Hello!" } ]
+        , descendantsCount = 1
+        , facts = emptyFacts
+        }
+
+
+keyedNodeWithChildren : Int -> Html.Html msg
+keyedNodeWithChildren childrenCount =
+    let
+        liWithText val =
+            ( toString val, Html.li [] [ Html.text (toString val) ] )
+    in
+        Keyed.ul [] <|
+            List.map liWithText [1..childrenCount]
+
+
+keyedNodeWithChildrenDecoded : Int -> NodeType
+keyedNodeWithChildrenDecoded childrenCount =
+    let
+        liWithTextDecoded val =
+            NodeEntry
+                { tag = "li"
+                , children = [ TextTag { text = toString val } ]
+                , descendantsCount = 1
+                , facts = emptyFacts
+                }
+    in
+        NodeEntry
+            { tag = "ul"
+            , children = List.map (toString >> liWithTextDecoded) [1..childrenCount]
+            , descendantsCount = childrenCount
+            , facts = emptyFacts
+            }
+
+
 
 -- HELPERS
 
@@ -369,6 +411,12 @@ nodeTests =
             <| assertEqualPair ( twoChildFormAsString, htmlToString twoChildForm )
         , test "forms with two non-empty text children are decoded to just a form with text"
             <| assertEqualPair ( twoChildFormDecoded, nodeTypeFromHtml twoChildForm )
+        , test "ul with a child text node"
+            <| assertEqualPair ( keyedNodeWithTextDecoded, nodeTypeFromHtml keyedNodeWithText )
+        , test "ul with one non-empty child is decoded"
+            <| assertEqualPair ( keyedNodeWithChildrenDecoded 1, nodeTypeFromHtml <| keyedNodeWithChildren 1 )
+        , test "ul with two non-empty children are decoded"
+            <| assertEqualPair ( keyedNodeWithChildrenDecoded 2, nodeTypeFromHtml <| keyedNodeWithChildren 2 )
         ]
 
 

--- a/tests/BasicTests.elm
+++ b/tests/BasicTests.elm
@@ -301,6 +301,36 @@ keyedNodeWithTextDecoded =
         }
 
 
+keyedNodeOneChild : Html.Html msg
+keyedNodeOneChild =
+    keyedNodeWithChildren 1
+
+
+keyedNodeOneChildDecoded : NodeType
+keyedNodeOneChildDecoded =
+    keyedNodeWithChildrenDecoded 1
+
+
+keyedNodeTwoChildren : Html.Html msg
+keyedNodeTwoChildren =
+    keyedNodeWithChildren 2
+
+
+keyedNodeTwoChildrenDecoded : NodeType
+keyedNodeTwoChildrenDecoded =
+    keyedNodeWithChildrenDecoded 2
+
+
+keyedNodeOneKeyedChild : Html.Html msg
+keyedNodeOneKeyedChild =
+    keyedNodeWithKeyedChildren 1
+
+
+keyedNodeTwoKeyedChildren : Html.Html msg
+keyedNodeTwoKeyedChildren =
+    keyedNodeWithKeyedChildren 2
+
+
 
 -- HELPERS
 
@@ -375,12 +405,6 @@ keyedNodeWithKeyedChildren childrenCount =
             List.map liWithText [1..childrenCount]
 
 
--- alias for keyedNodeWithChildrenDecoded
-keyedNodeWithKeyedChildrenDecoded : Int -> NodeType
-keyedNodeWithKeyedChildrenDecoded =
-    keyedNodeWithChildrenDecoded
-
-
 
 -- TESTS
 
@@ -439,13 +463,13 @@ nodeTests =
         , test "ul with a child text node"
             <| assertEqualPair ( keyedNodeWithTextDecoded, nodeTypeFromHtml keyedNodeWithText )
         , test "ul with one non-empty child is decoded"
-            <| assertEqualPair ( keyedNodeWithChildrenDecoded 1, nodeTypeFromHtml <| keyedNodeWithChildren 1 )
+            <| assertEqualPair ( keyedNodeOneChildDecoded, nodeTypeFromHtml keyedNodeOneChild )
         , test "ul with two non-empty children are decoded"
-            <| assertEqualPair ( keyedNodeWithChildrenDecoded 2, nodeTypeFromHtml <| keyedNodeWithChildren 2 )
+            <| assertEqualPair ( keyedNodeTwoChildrenDecoded, nodeTypeFromHtml keyedNodeTwoChildren )
         , test "ul with one non-empty keyed child is decoded"
-            <| assertEqualPair ( keyedNodeWithKeyedChildrenDecoded 1, nodeTypeFromHtml <| keyedNodeWithKeyedChildren 1 )
+            <| assertEqualPair ( keyedNodeOneChildDecoded, nodeTypeFromHtml keyedNodeOneKeyedChild )
         , test "ul with two non-empty keyed children are decoded"
-            <| assertEqualPair ( keyedNodeWithKeyedChildrenDecoded 2, nodeTypeFromHtml <| keyedNodeWithKeyedChildren 2 )
+            <| assertEqualPair ( keyedNodeTwoChildrenDecoded, nodeTypeFromHtml keyedNodeTwoKeyedChildren )
         ]
 
 

--- a/tests/BasicTests.elm
+++ b/tests/BasicTests.elm
@@ -131,6 +131,12 @@ emptyDivWithAttributeDecoded =
 
 emptyDivWithManyAttributes : Html.Html msg
 emptyDivWithManyAttributes =
+    --Html.div
+    --    [ Html.Attributes.class "dog"
+    --    , Html.Attributes.value "cat"
+    --    , Html.Attributes.width 50
+    --    ]
+    --[]
     emptyDiv
         |> addAttribute (Html.Attributes.class "dog")
         |> addAttribute (Html.Attributes.value "cat")

--- a/tests/BasicTests.elm
+++ b/tests/BasicTests.elm
@@ -10,6 +10,7 @@ import ElmTest exposing (..)
 import Html
 import Html.Attributes
 import Html.Events
+import Html.Keyed as Keyed
 import Dict
 import String
 import Json.Encode
@@ -187,6 +188,20 @@ emptyDivWithStyleDecoded =
         }
 
 
+emptyKeyedNode : Html.Html msg
+emptyKeyedNode =
+    Keyed.ul [] []
+
+
+emptyKeyedUlDecoded : NodeType
+emptyKeyedUlDecoded =
+    NodeEntry
+        { tag = "ul"
+        , children = []
+        , descendantsCount = 0
+        , facts = emptyFacts
+        }
+
 
 -- Non empty things!
 
@@ -328,6 +343,8 @@ nodeTests =
             <| assertEqualPair ( emptyDivWithAddedAttributeAsString, htmlToString emptyDivWithAddedAttribute )
         , test "empty divs are decoded to empty div nodes"
             <| assertEqualPair ( emptyDivWithAddedAttributeDecoded, nodeTypeFromHtml emptyDivWithAddedAttribute )
+        , test "empty keyed ul is decoded to empty ul node"
+            <| assertEqualPair ( emptyKeyedUlDecoded, nodeTypeFromHtml emptyKeyedNode)
         , test "empty divs with classes get classes as a string"
             <| assertEqualPair ( emptyDivWithAttributeAsString, htmlToString emptyDivWithAttribute )
         , test "empty divs with classes are decoded to empty div nodes with classes"
@@ -378,6 +395,11 @@ queryTests =
                 <| assertEqualPair
                     ( [ nodeTypeFromHtml emptyDiv ]
                     , queryByTagname "div" emptyDiv
+                    )
+            , test "query by tagname finds a keyed node"
+                <| assertEqualPair
+                    ( [ nodeTypeFromHtml emptyKeyedNode ]
+                    , queryByTagname "ul" emptyKeyedNode
                     )
             , test "query finds all nodes by tagname"
                 <| assertEqualPair

--- a/tests/BasicTests.elm
+++ b/tests/BasicTests.elm
@@ -301,49 +301,6 @@ keyedNodeWithTextDecoded =
         }
 
 
-keyedNodeWithChildren : Int -> Html.Html msg
-keyedNodeWithChildren childrenCount =
-    let
-        liWithText val =
-            ( toString val, Html.li [] [ Html.text (toString val) ] )
-    in
-        Keyed.ul [] <|
-            List.map liWithText [1..childrenCount]
-
-
-keyedNodeWithChildrenDecoded : Int -> NodeType
-keyedNodeWithChildrenDecoded childrenCount =
-    let
-        liWithTextDecoded val =
-            NodeEntry
-                { tag = "li"
-                , children = [ TextTag { text = val } ]
-                , descendantsCount = 1
-                , facts = emptyFacts
-                }
-    in
-        NodeEntry
-            { tag = "ul"
-            , children = List.map (toString >> liWithTextDecoded) [1..childrenCount]
-            , descendantsCount = childrenCount * 2
-            , facts = emptyFacts
-            }
-
-
-keyedNodeWithKeyedChildren : Int -> Html.Html msg
-keyedNodeWithKeyedChildren childrenCount =
-    let
-        liWithText val =
-            ( toString val, Keyed.node "li" [] [ ("1", Html.text (toString val)) ] )
-    in
-        Keyed.ul [] <|
-            List.map liWithText [1..childrenCount]
-
-
-keyedNodeWithKeyedChildrenDecoded : Int -> NodeType
-keyedNodeWithKeyedChildrenDecoded =
-    keyedNodeWithChildrenDecoded
-
 
 -- HELPERS
 
@@ -374,6 +331,54 @@ countDescendents nodeType =
 
         _ ->
             0
+
+
+-- creates a keyed `ul` with `n` children (`li`).
+keyedNodeWithChildren : Int -> Html.Html msg
+keyedNodeWithChildren childrenCount =
+    let
+        liWithText val =
+            ( toString val, Html.li [] [ Html.text (toString val) ] )
+    in
+        Keyed.ul [] <|
+            List.map liWithText [1..childrenCount]
+
+
+-- creates a decoded keyed `ul` with `n` children (`li`).
+keyedNodeWithChildrenDecoded : Int -> NodeType
+keyedNodeWithChildrenDecoded childrenCount =
+    let
+        liWithTextDecoded val =
+            NodeEntry
+                { tag = "li"
+                , children = [ TextTag { text = val } ]
+                , descendantsCount = 1
+                , facts = emptyFacts
+                }
+    in
+        NodeEntry
+            { tag = "ul"
+            , children = List.map (toString >> liWithTextDecoded) [1..childrenCount]
+            , descendantsCount = childrenCount * 2
+            , facts = emptyFacts
+            }
+
+
+-- creates a keyed `ul` with `n` keyed children (`li`).
+keyedNodeWithKeyedChildren : Int -> Html.Html msg
+keyedNodeWithKeyedChildren childrenCount =
+    let
+        liWithText val =
+            ( toString val, Keyed.node "li" [] [ ("1", Html.text (toString val)) ] )
+    in
+        Keyed.ul [] <|
+            List.map liWithText [1..childrenCount]
+
+
+-- alias for keyedNodeWithChildrenDecoded
+keyedNodeWithKeyedChildrenDecoded : Int -> NodeType
+keyedNodeWithKeyedChildrenDecoded =
+    keyedNodeWithChildrenDecoded
 
 
 

--- a/tests/BasicTests.elm
+++ b/tests/BasicTests.elm
@@ -324,6 +324,20 @@ keyedNodeWithChildrenDecoded childrenCount =
             }
 
 
+keyedNodeWithKeyedChildren : Int -> Html.Html msg
+keyedNodeWithKeyedChildren childrenCount =
+    let
+        liWithText val =
+            ( toString val, Keyed.node "li" [] [ ("1", Html.text (toString val)) ] )
+    in
+        Keyed.ul [] <|
+            List.map liWithText [1..childrenCount]
+
+
+keyedNodeWithKeyedChildrenDecoded : Int -> NodeType
+keyedNodeWithKeyedChildrenDecoded =
+    keyedNodeWithChildrenDecoded
+
 
 -- HELPERS
 
@@ -417,6 +431,10 @@ nodeTests =
             <| assertEqualPair ( keyedNodeWithChildrenDecoded 1, nodeTypeFromHtml <| keyedNodeWithChildren 1 )
         , test "ul with two non-empty children are decoded"
             <| assertEqualPair ( keyedNodeWithChildrenDecoded 2, nodeTypeFromHtml <| keyedNodeWithChildren 2 )
+        , test "ul with one non-empty keyed child is decoded"
+            <| assertEqualPair ( keyedNodeWithKeyedChildrenDecoded 1, nodeTypeFromHtml <| keyedNodeWithKeyedChildren 1 )
+        , test "ul with two non-empty keyed children are decoded"
+            <| assertEqualPair ( keyedNodeWithKeyedChildrenDecoded 2, nodeTypeFromHtml <| keyedNodeWithKeyedChildren 2 )
         ]
 
 

--- a/tests/BasicTests.elm
+++ b/tests/BasicTests.elm
@@ -311,7 +311,7 @@ keyedNodeWithChildrenDecoded childrenCount =
         liWithTextDecoded val =
             NodeEntry
                 { tag = "li"
-                , children = [ TextTag { text = toString val } ]
+                , children = [ TextTag { text = val } ]
                 , descendantsCount = 1
                 , facts = emptyFacts
                 }
@@ -319,7 +319,7 @@ keyedNodeWithChildrenDecoded childrenCount =
         NodeEntry
             { tag = "ul"
             , children = List.map (toString >> liWithTextDecoded) [1..childrenCount]
-            , descendantsCount = childrenCount
+            , descendantsCount = childrenCount * 2
             , facts = emptyFacts
             }
 

--- a/tests/BasicTests.elm
+++ b/tests/BasicTests.elm
@@ -132,12 +132,6 @@ emptyDivWithAttributeDecoded =
 
 emptyDivWithManyAttributes : Html.Html msg
 emptyDivWithManyAttributes =
-    --Html.div
-    --    [ Html.Attributes.class "dog"
-    --    , Html.Attributes.value "cat"
-    --    , Html.Attributes.width 50
-    --    ]
-    --[]
     emptyDiv
         |> addAttribute (Html.Attributes.class "dog")
         |> addAttribute (Html.Attributes.value "cat")


### PR DESCRIPTION
Allows for use of the HtmlQuery library when using Html.Keyed.

I considered introducing a new internal type for `KeyedNodeEntry`, but did not do so because I felt unsure about the scope of impact that would have. I'm not sure, for the purposes of this library, whether it's worth making a distinction.

Happy to rewrite this PR/close this PR if that would be your preference.

Should fix test failures on https://github.com/NoRedInk/NoRedInk/pull/14191 (cc @scottcorgan)